### PR TITLE
Fix double hyphens in `systemctl enable --now`

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@ layout: default
                         <p>Use one of the <a class="external" href="https://wiki.archlinux.org/index.php/AUR_helpers">AUR helpers</a> to install snapd. For example, with pacaur:</p>
                         <pre class="command-line"><code>pacaur -S snapd
 # enable the snapd systemd service:
-sudo systemctl enable –now snapd.service</code></pre>
+sudo systemctl enable --now snapd.service</code></pre>
                         
                     </div>
                 </div>
@@ -95,7 +95,7 @@ sudo yum install snapd</code></pre>
                         <pre class="command-line"><code>sudo dnf copr enable zyga/snapcore.
 sudo dnf install snapd
 # enable the snapd systemd service:
-sudo systemctl enable –now snapd.service
+sudo systemctl enable --now snapd.service
 
 # SELinux support is in beta, so on Fedora 24 you currently have to:
 sudo setenforce 0
@@ -107,7 +107,7 @@ sudo setenforce 0
                         <h3 class="accessibility-aid">Gentoo</h3>
                         <p>Install <a href="https://github.com/zyga/snap-confine-gentoo">snap-confine.ebuild</a> then <a href="https://github.com/zyga/snapd-gentoo".>snapd.ebuild</a></p>
                         <pre class="command-line"><code># enable the snapd systemd service:
-sudo systemctl enable –now snapd.service</code></pre>
+sudo systemctl enable --now snapd.service</code></pre>
 
                     </div>
                 </div>


### PR DESCRIPTION
## Context

http://snapcraft.io/ shows en dashes instead of double hyphens in three systemctl commands, which systemctl can't handle.

## Done
changed en dash to double hyphens in three places

## QA
Check double hyphen appears in each systemctl command.