### PR TITLE
Remove typo in Fedora instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@ sudo yum install snapd</code></pre>
                     <div class="eight-col">
                         <h3 class="accessibility-aid">Fedora instructions</h3>
                         <p>On Fedora 23 or 24:</p>
-                        <pre class="command-line"><code>sudo dnf copr enable zyga/snapcore.
+                        <pre class="command-line"><code>sudo dnf copr enable zyga/snapcore
 sudo dnf install snapd
 # enable the snapd systemd service:
 sudo systemctl enable --now snapd.service


### PR DESCRIPTION
## Done

Remove period from Copr repo name.

```pytb
[vagrant@localhost ~]$ sudo dnf copr enable zyga/snapcore.

You are about to enable a Copr repository. Please note that this
repository is not part of the main Fedora distribution, and quality
may vary.

The Fedora Project does not exercise any power over the contents of
this repository beyond the rules outlined in the Copr FAQ at
<https://fedorahosted.org/copr/wiki/UserDocs#WhatIcanbuildinCopr>, and
packages are not held to any quality or security level.

Please do not file bug reports about these packages in Fedora
Bugzilla. In case of problems, contact the owner of this repository.

Do you want to continue? [y/N]: y
Traceback (most recent call last):
  File "/usr/lib/python3.4/site-packages/dnfpluginscore/lib.py", line 71, in urlopen
    librepo.download_url(url, fo.fileno(), handle)
  File "/usr/lib64/python3.4/site-packages/librepo/__init__.py", line 1517, in download_url
    return _librepo.download_url(handle, url, fd)
librepo.LibrepoException: (10, 'Status code: 404 for https://copr.fedorainfracloud.org/coprs/zyga/snapcore./repo/fedora-23/', 'Error HTTP/FTP status code')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.4/site-packages/dnf-plugins/copr.py", line 249, in _download_repo
    f = dnfpluginscore.lib.urlopen(self, None, self.copr_url + api_path, 'w+')
  File "/usr/lib/python3.4/site-packages/dnfpluginscore/lib.py", line 73, in urlopen
    raise IOError(e.args[1])
OSError: Status code: 404 for https://copr.fedorainfracloud.org/coprs/zyga/snapcore./repo/fedora-23/

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/bin/dnf", line 35, in <module>
    main.user_main(sys.argv[1:], exit_code=True)
  File "/usr/lib/python3.4/site-packages/dnf/cli/main.py", line 198, in user_main
    errcode = main(args)
  File "/usr/lib/python3.4/site-packages/dnf/cli/main.py", line 84, in main
    return _main(base, args)
  File "/usr/lib/python3.4/site-packages/dnf/cli/main.py", line 136, in _main
    cli.run()
  File "/usr/lib/python3.4/site-packages/dnf/cli/cli.py", line 1091, in run
    return self.command.run(self.base.extcmds)
  File "/usr/lib/python3.4/site-packages/dnf-plugins/copr.py", line 138, in run
    self._download_repo(project_name, repo_filename, chroot)
  File "/usr/lib/python3.4/site-packages/dnf-plugins/copr.py", line 257, in _download_repo
    res = urllib.request.urlopen(self.copr_url + "/coprs/" + project_name, 'w+')
  File "/usr/lib64/python3.4/urllib/request.py", line 161, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib64/python3.4/urllib/request.py", line 461, in open
    req = meth(req)
  File "/usr/lib64/python3.4/urllib/request.py", line 1112, in do_request_
    raise TypeError(msg)
TypeError: POST data should be bytes or an iterable of bytes. It cannot be of type str.
```

## QA

Run the command.
