### PR TITLE
Highlight the arch section of the code snippet

### DIFF
--- a/create/index.html
+++ b/create/index.html
@@ -591,6 +591,8 @@ apps:
     daemon: simple
     plugs:
     - network-bind
+  <b>architectures:
+  - amd64</b>
 confinement: strict
 description: This example demonstrates how to have nodejs webserver. This is part
   of the snapcraft tour at https://snapcraft.io/create/
@@ -598,7 +600,7 @@ name: hello-world-service
 summary: A hello world style nodejs webserver app
 version: 0.1</code></pre>
 
-            <p>The first exception is that <code>snap.yaml</code> includes a specification of the architecture that the snap has been built for (highlighted). The second difference is that there is no parts definition (as the parts are now in the snap and no longer need to be defined).</p>
+            <p>The first exception is that <code>snap.yaml</code> includes a specification of the architecture that the snap has been built for <strong>(highlighted)</strong>. The second difference is that there is no parts definition (as the parts are now in the snap and no longer need to be defined).</p>
 
             <p>Armed with this information you can, if you wish, build your snap package more directly by:</p>
 


### PR DESCRIPTION
## Done
- Added and highlighted the architectures section of the of the snap.yaml example
- Highlight the `(highlight)` text to help find and match when skimming content

## QA
- Run `gulp`
- Go to `http://localhost:3000/create/`
- Find the section with `The first exception is that`
- Check that the `architectures` part of the code above is highlighted and that the (highlight) section of the sentence below is bolder (or normal) font weight
- Check that this matches the copy doc [1]
- Check that these truly fixes the issue [2]

## Issue / Card

[1] https://docs.google.com/document/d/182l_u_9neVZS2ZOYHjdemi7wHju89-JqOgJCHcM-JQQ/edit
[2] Fixes: https://github.com/ubuntudesign/snapcraft.io/issues/17

