### PR TITLE
New docs navigation & Fix bugs 141, 130, 127 & 126

### DIFF
--- a/_includes/footer-legal.html
+++ b/_includes/footer-legal.html
@@ -1,0 +1,8 @@
+<p class="footer__text">&copy; 2016 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
+
+<ul class="footer__links">
+    <li class="footer__list-item"><a href="http://www.ubuntu.com/legal">Legal information</a><span class="footer__dot"> &#183;</span></li>
+    <li class="footer__list-item"><a href="https://github.com/ubuntudesign/snapcraft.io/issues/new">Report a bug on this site</a></li>
+</ul>
+
+<span class="accessibility-aid"><a href="#">Go to the top of the page</a></span>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,7 +1,5 @@
-<!-- Footer -->
 <div class="wrapper">
     <footer class="footer">
-
       <div class="footer__social right">
         <h3 class="footer__heading">Follow us</h3>
         <ul class="social-list inline-list clearfix">
@@ -17,13 +15,7 @@
         </ul>
       </div>
 
-        <p class="footer__text">&copy; 2016 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
-
-        <ul class="footer__links">
-            <li class="footer__list-item"><a href="http://www.ubuntu.com/legal">Legal information</a><span class="footer__dot"> &#183;</span></li>
-            <li class="footer__list-item"><a href="https://github.com/ubuntudesign/snapcraft.io/issues/new">Report a bug on this site</a></li>
-        </ul>
-
+      {% include footer-legal.html %}
     </footer>
 </div>
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -17,6 +17,5 @@
     <link rel="apple-touch-icon-precomposed" sizes="72x72" href="{{ site.asset_path }}09460d9a-apple-touch-icon-72x72-precomposed.png" />
     <link rel="apple-touch-icon-precomposed" href="{{ site.asset_path }}cc66da65-apple-touch-icon-precomposed.png" />
 
-    <link rel="stylesheet" href="/css/main.css">
-
+    <link rel="stylesheet" href="{% if css_path %}{{ css_path }}{% else %}/css/main.css{% endif %}">
 </head>

--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -28,43 +28,45 @@
         {% include header.html %}
 
         <div class="wrapper">
-            <div class="content">
-                <div class="row documentation no-border">
-                    <nav class="documentation__nav">
-                        {% include docs-navigation.html %}
+            <div class="row documentation no-border">
+                <nav class="documentation__nav">
+                    {% include docs-navigation.html %}
 
-                        <script>
-                            function expandCollapse(clickEvent) {
-                                var item = clickEvent.target;
-                                var link = item.querySelector('[href]');
-                                var linkWidth = link.offsetWidth;
-                                var clickOffset = clickEvent.offsetX;
+                    <script>
+                        function expandCollapse(clickEvent) {
+                            var item = clickEvent.target;
+                            var link = item.querySelector('[href]');
+                            var linkWidth = link.offsetWidth;
+                            var clickOffset = clickEvent.offsetX;
 
-                                if (clickOffset > linkWidth) {
-                                    collapsed = ! item.classList.toggle('expanded');
-                                    item.classList.toggle('collapsed', collapsed);
-                                }
+                            if (clickOffset > linkWidth) {
+                                collapsed = ! item.classList.toggle('expanded');
+                                item.classList.toggle('collapsed', collapsed);
+                            }
+                        }
+
+                        var items = document.querySelectorAll('.documentation__nav ul li');
+
+                        for(var num = 0; num < items.length; num++) {
+                            var item = items[num];
+                            var link = item.querySelector('[href]');
+
+                            if (! link) {continue;}
+
+                            // Get paths, removing leading and trailing slashes for consistency
+                            linkPath = link.pathname.replace(/(^\/|\/$)/g, "");
+                            currentPath = location.pathname.replace(/(^\/|\/$)/g, "");
+
+                            // Make current navigation item appear active
+                            // @TODO: Replace this with a static JS-less solution
+                            //        once we have a more intelligent
+                            //        docs navigation mechanism.
+                            if (linkPath == currentPath) {
+                                link.classList.add('active');
                             }
 
-                            var items = document.querySelectorAll('.documentation__nav ul li');
-
-                            for(var num = 0; num < items.length; num++) {
-                                var item = items[num];
-
-                                // only act on items with child lists
-                                if (! item.querySelector('ul')) {
-                                    continue;
-                                }
-
-                                var link = item.querySelector('[href]');
-
-                                linkPath = link.pathname;
-                                currentPath = location.pathname;
-
-                                if (linkPath.substring(0, 1) != '/') {
-                                  linkPath = '/' + linkPath;
-                                }
-
+                            // For lists with child lists, add expand/collapse functionality
+                            if (item.querySelector('ul')) {
                                 if (currentPath.startsWith(linkPath)) {
                                     item.classList.add('expanded');
                                 } else {
@@ -73,15 +75,13 @@
 
                                 item.addEventListener('click', expandCollapse);
                             }
-                        </script>
-                    </nav>
-                    <main class="documentation__content">
-                        <h1 id="introduction">{{ page.title }}</h1>
-                        {{ content }}
-                    </main>
-                    <aside class="jujudocs__toc">
-                    </aside>
-                </div>
+                        }
+                    </script>
+                </nav>
+                <main class="documentation__content">
+                    <h1 id="introduction">{{ page.title }}</h1>
+                    {{ content }}
+                </main>
             </div>
         </div>
 

--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -98,20 +98,10 @@
             </div>
         </div>
 
-        <footer class="global clearfix no-global">
-            <nav id="main-navigation" role="navigation" class="clearfix">
-                <div class="legal clearfix has-cookie">
-                    <p class="twelve-col">© 2016 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
-                    <ul class="inline-list clear">
-                        <li><a href="/legal"><small>Legal information</small></a>
-                        </li>
-                        <li><a href="https://bugs.launchpad.net/ubuntu-website-content/"><small>Report a bug on this site</small></a>
-                        </li>
-                    </ul>
-                    <span class="accessibility-aid"><a href="#">Got to the top of the page</a></span>
-                </div>
-            </nav>
+        <footer class="footer-wrapper">
+            {% include footer-legal.html %}
         </footer>
+
         {% include analytics.html %}
     </body>
 </html>

--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -98,7 +98,7 @@
             </div>
         </div>
 
-        <footer class="global clearfix no-global wrapper">
+        <footer class="global clearfix no-global">
             <nav id="main-navigation" role="navigation" class="clearfix">
                 <div class="legal clearfix has-cookie">
                     <p class="twelve-col">© 2016 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>

--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -1,13 +1,9 @@
 <!DOCTYPE html>
 <html>
-    <head>
-        <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
+    {% assign css_path = '/css/docs.css' %}
+    {% include head.html %}
 
-        <title>{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
-
+    <body class="docs">
         <script>
           /**
            * Polyfills:
@@ -16,9 +12,6 @@
            * String.startsWith requires polyfill for all IEs
            * Element.addEventListener requires polyfill for IE8
            */
-
-          /* HTML5 element support */
-          for(var e,l='article aside footer header nav section time'.split(' ');e=l.pop();document.createElement(e));
 
           /* Element.prototype.classList polyfill, by Eli Grey, http://eligrey.com
            * https://github.com/eligrey/classList.js */
@@ -32,12 +25,6 @@
           String.prototype.startsWith||!function(){"use strict";var t=function(){try{var t={},r=Object.defineProperty,e=r(t,t,t)&&r}catch(n){}return e}(),r={}.toString,e=function(t){if(null==this)throw TypeError();var e=String(this);if(t&&"[object RegExp]"==r.call(t))throw TypeError();var n=e.length,i=String(t),a=i.length,o=arguments.length>1?arguments[1]:void 0,h=o?Number(o):0;h!=h&&(h=0);var u=Math.min(Math.max(h,0),n);if(a+u>n)return!1;for(var g=-1;++g<a;)if(e.charCodeAt(u+g)!=i.charCodeAt(g))return!1;return!0};t?t(String.prototype,"startsWith",{value:e,configurable:!0,writable:!0}):String.prototype.startsWith=e}();
         </script>
 
-        <link rel="stylesheet" href="{{ "/css/docs.css" | prepend: site.baseurl }}">
-        <link rel="canonical" href="{{ page.url }}">
-        <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}">
-    </head>
-
-    <body class="docs">
         {% include header.html %}
 
         <div class="wrapper">

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -4,6 +4,10 @@
   margin: auto;
   padding: 1rem;
 
+  .docs & {
+    padding: 0;
+  }
+
   @media only screen and (min-width: $breakpoint-medium) {
     padding: 0;
   }

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -61,16 +61,16 @@
 
 // inline code blocks
 .command-inline {
-    position: relative;
-    display: inline;
-    border-radius: 4px;
-    background-color: none;
-    overflow: hidden;
-    font-size: 1em;
-    font-family: Ubuntu Mono;
-    font-weight: 300;
-    padding: 0;
-    width: 100%;
+  position: relative;
+  display: inline;
+  border-radius: 4px;
+  background-color: none;
+  overflow: hidden;
+  font-size: 1em;
+  font-family: Ubuntu Mono;
+  font-weight: 300;
+  padding: 0;
+  width: 100%;
 }
 
 // complementing note

--- a/_sass/_docs-footer.scss
+++ b/_sass/_docs-footer.scss
@@ -1,6 +1,0 @@
-footer.global {
-  padding-left: 20px;
-}
-footer.global .legal {
-  width: auto; // Override vanilla
-}

--- a/_sass/_documentation.scss
+++ b/_sass/_documentation.scss
@@ -252,3 +252,19 @@
         width: $navigation-width;
     }
 }
+
+// Make main section fill the vertical space (sticky footer)
+.docs {
+  display: flex;
+  min-height: 100vh;
+  flex-direction: column;
+}
+
+.docs .wrapper {
+  flex: 1;
+  display: flex;
+}
+
+.documentation {
+  flex: 1;
+}

--- a/_sass/_documentation.scss
+++ b/_sass/_documentation.scss
@@ -55,7 +55,7 @@
 
         &:after {
           width: $button-width;
-          height: 1.5em;
+          height: 1.875em;
           display: block;
           position: absolute;
           top: $gutter / 2;

--- a/_sass/_documentation.scss
+++ b/_sass/_documentation.scss
@@ -11,13 +11,13 @@
         $gutter: 20px;
         $button-width: 10px;
 
-        font-size: 1.2em;
+        // To enabling hiding of the bottom-most border in the navigation
+        overflow: hidden;
 
         @media only screen and (min-width: $breakpoint-medium) {
             border-right: 1px solid #ccc;
             width: $navigation-width;
             min-width: $navigation-width;
-            padding-top: $gutter;
         }
 
         ul {
@@ -26,65 +26,102 @@
             padding-left: 0;
             padding-right: 0;
 
+            -moz-user-select: none;
+            -khtml-user-select: none;
+            -webkit-user-select: none;
+            -ms-user-select: none;
+            user-select: none;
+
             li {
                 padding-left: $gutter;
                 padding-right: $gutter;
+                padding-top: 7px;
 
                 margin: 0;
                 position: relative;
 
                 a {
                     display: block;
-                    color: #333;
+                    color: #333333;
 
-                    &:hover {
-                      color: #e95420;
+                    &:hover, &:focus {
                       text-decoration: none;
+                    }
+
+                    &:hover, &.active {
+                        color: #e95420;
                     }
                 }
 
-                &.collapsed ul {
-                  display: none;
-                }
-
-
-                &.expanded > ul {
-                  display: block;
-                }
-
                 &:after {
-                  width: $button-width;
-                  display: block;
-                  position: absolute;
-                  top: 0;
-                  right: $gutter;
-                  cursor: pointer;
+                    width: $button-width;
+                    height: 1.5em;
+                    display: block;
+                    position: absolute;
+                    top: $gutter / 2;
+                    right: $gutter;
+                    cursor: pointer;
                 }
-                &.collapsed:after {
-                  content: '+';
+
+                &.collapsed {
+                    padding-right: $gutter + $button-width;
+
+                    & > ul {
+                        display: none;
+                    }
+
+                    &:after {
+                        content: '+';
+                    }
                 }
-                &.expanded:after {
-                  content: '-';
+
+                &.expanded {
+                    & > ul {
+                        display: block;
+                    }
+                    &:after {
+                        content: '-';
+                    }
                 }
             }
         }
 
-        // & > ul {
-        //     & > li {
-        //         padding-top: $gutter / 2;
-        //         padding-bottom: $gutter / 2;
-        //         border-bottom: 1px solid #333;
-        //
-        //         &.collapsed:after {
-        //             content: '';
-        //             background-image: url('https://assets.ubuntu.com/v1/04d2075a-chevron_down.svg');
-        //         }
-        //         &.expanded:after {
-        //             content: '';
-        //             background-image: url('https://assets.ubuntu.com/v1/f3f43376-chevron_up.svg');
-        //         }
-        //     }
-        // }
+        & > ul {
+            // Hide the bottom-most border
+            // only if it's pushing right up against the footer
+            // so we don't get an ugly double-border effect
+            margin-bottom: -1px;
+
+            & > li {
+                border-bottom: 1px dotted #b2b2b2;
+                padding-top: $gutter / 2;
+                padding-bottom: $gutter / 2;
+
+                & > a {
+                  font-size: 1.25em;
+                }
+
+                & > ul {
+                    & > li {
+                        padding-left: 0;
+                        padding-right: 0;
+                    }
+                }
+
+                &:after {
+                    background-position: center center;
+                    background-repeat: no-repeat;
+                }
+                &.collapsed:after {
+                    content: '';
+                    background-image: url('https://assets.ubuntu.com/v1/04d2075a-chevron_down.svg');
+                }
+                &.expanded:after {
+                    content: '';
+                    background-image: url('https://assets.ubuntu.com/v1/f3f43376-chevron_up.svg');
+                }
+            }
+        }
 
         // Top level sections get bottom padding.
         .section {
@@ -245,11 +282,6 @@
                 color: $mid-grey;
             }
         }
-    }
-
-    &__toc {
-        min-width: $navigation-width;
-        width: $navigation-width;
     }
 }
 

--- a/_sass/_documentation.scss
+++ b/_sass/_documentation.scss
@@ -249,7 +249,7 @@
   }
 
   &__content {
-    padding: 10px;
+    padding: 20px;
 
     @media only screen and (min-width: $breakpoint-medium) {
       padding: 20px 40px;

--- a/_sass/_documentation.scss
+++ b/_sass/_documentation.scss
@@ -1,288 +1,288 @@
 .documentation {
-    background-color: $white;
-    padding: 0;
-    display: flex;
+  background-color: $white;
+  padding: 0;
+  display: flex;
 
-    @media only screen and (max-width: $breakpoint-medium) {
-        flex-direction: column;
+  @media only screen and (max-width: $breakpoint-medium) {
+    flex-direction: column;
+  }
+
+  &__nav {
+    $gutter: 20px;
+    $button-width: 10px;
+
+    // To enabling hiding of the bottom-most border in the navigation
+    overflow: hidden;
+
+    @media only screen and (min-width: $breakpoint-medium) {
+      border-right: 1px solid #ccc;
+      width: $navigation-width;
+      min-width: $navigation-width;
     }
 
-    &__nav {
-        $gutter: 20px;
-        $button-width: 10px;
+    ul {
+      list-style: none;
+      margin: 0;
+      padding-left: 0;
+      padding-right: 0;
 
-        // To enabling hiding of the bottom-most border in the navigation
-        overflow: hidden;
+      -moz-user-select: none;
+      -khtml-user-select: none;
+      -webkit-user-select: none;
+      -ms-user-select: none;
+      user-select: none;
 
-        @media only screen and (min-width: $breakpoint-medium) {
-            border-right: 1px solid #ccc;
-            width: $navigation-width;
-            min-width: $navigation-width;
+      li {
+        padding-left: $gutter;
+        padding-right: $gutter;
+        padding-top: 7px;
+
+        margin: 0;
+        position: relative;
+
+        a {
+          display: block;
+          color: #333333;
+
+          &:hover, &:focus {
+            text-decoration: none;
+          }
+
+          &:hover, &.active {
+            color: #e95420;
+          }
         }
 
-        ul {
-            list-style: none;
-            margin: 0;
-            padding-left: 0;
-            padding-right: 0;
+        &:after {
+          width: $button-width;
+          height: 1.5em;
+          display: block;
+          position: absolute;
+          top: $gutter / 2;
+          right: $gutter;
+          cursor: pointer;
+        }
 
-            -moz-user-select: none;
-            -khtml-user-select: none;
-            -webkit-user-select: none;
-            -ms-user-select: none;
-            user-select: none;
+        &.collapsed {
+          padding-right: $gutter + $button-width;
 
-            li {
-                padding-left: $gutter;
-                padding-right: $gutter;
-                padding-top: 7px;
+          & > ul {
+            display: none;
+          }
 
-                margin: 0;
-                position: relative;
+          &:after {
+            content: '+';
+          }
+        }
 
-                a {
-                    display: block;
-                    color: #333333;
+        &.expanded {
+          & > ul {
+            display: block;
+          }
+          &:after {
+            content: '-';
+          }
+        }
+      }
+    }
 
-                    &:hover, &:focus {
-                      text-decoration: none;
-                    }
+    & > ul {
+      // Hide the bottom-most border
+      // only if it's pushing right up against the footer
+      // so we don't get an ugly double-border effect
+      margin-bottom: -1px;
 
-                    &:hover, &.active {
-                        color: #e95420;
-                    }
-                }
+      & > li {
+        border-bottom: 1px dotted #b2b2b2;
+        padding-top: $gutter / 2;
+        padding-bottom: $gutter / 2;
 
-                &:after {
-                    width: $button-width;
-                    height: 1.5em;
-                    display: block;
-                    position: absolute;
-                    top: $gutter / 2;
-                    right: $gutter;
-                    cursor: pointer;
-                }
-
-                &.collapsed {
-                    padding-right: $gutter + $button-width;
-
-                    & > ul {
-                        display: none;
-                    }
-
-                    &:after {
-                        content: '+';
-                    }
-                }
-
-                &.expanded {
-                    & > ul {
-                        display: block;
-                    }
-                    &:after {
-                        content: '-';
-                    }
-                }
-            }
+        & > a {
+          font-size: 1.25em;
         }
 
         & > ul {
-            // Hide the bottom-most border
-            // only if it's pushing right up against the footer
-            // so we don't get an ugly double-border effect
-            margin-bottom: -1px;
-
-            & > li {
-                border-bottom: 1px dotted #b2b2b2;
-                padding-top: $gutter / 2;
-                padding-bottom: $gutter / 2;
-
-                & > a {
-                  font-size: 1.25em;
-                }
-
-                & > ul {
-                    & > li {
-                        padding-left: 0;
-                        padding-right: 0;
-                    }
-                }
-
-                &:after {
-                    background-position: center center;
-                    background-repeat: no-repeat;
-                }
-                &.collapsed:after {
-                    content: '';
-                    background-image: url('https://assets.ubuntu.com/v1/04d2075a-chevron_down.svg');
-                }
-                &.expanded:after {
-                    content: '';
-                    background-image: url('https://assets.ubuntu.com/v1/f3f43376-chevron_up.svg');
-                }
-            }
+          & > li {
+            padding-left: 0;
+            padding-right: 0;
+          }
         }
 
-        // Top level sections get bottom padding.
-        .section {
-            padding: 0 0 20px;
-            // Subsections & collapsed sections get no padding.
-            &.collapsed, .section {
-                padding: 0;
-            }
+        &:after {
+          background-position: center center;
+          background-repeat: no-repeat;
+        }
+        &.collapsed:after {
+          content: '';
+          background-image: url('https://assets.ubuntu.com/v1/04d2075a-chevron_down.svg');
+        }
+        &.expanded:after {
+          content: '';
+          background-image: url('https://assets.ubuntu.com/v1/f3f43376-chevron_up.svg');
+        }
+      }
+    }
+
+    // Top level sections get bottom padding.
+    .section {
+      padding: 0 0 20px;
+      // Subsections & collapsed sections get no padding.
+      &.collapsed, .section {
+        padding: 0;
+      }
+    }
+
+    .search-form {
+      @include rounded_corners(3px);
+      position: relative;
+      width: 100%;
+      max-width: 100%;
+      margin: 0 0 20px 0;
+      padding: 0;
+
+      input[type="text"] {
+        @include box-shadow(none);
+        position: relative;
+        background-color: #fff;
+        height: 40px;
+        border: 1px solid $light-mid-grey;
+        padding-left: 35px;
+        color: $cool-grey;
+
+        &:focus {
+          border: 1px solid #9D9C9A;
+          outline: none;
         }
 
-        .search-form {
-            @include rounded_corners(3px);
-            position: relative;
-            width: 100%;
-            max-width: 100%;
-            margin: 0 0 20px 0;
+        &::-webkit-input-placeholder {
+          color: $cool-grey;
+          font-size: 1em;
+          opacity: 1;
+        }
+        &:-moz-placeholder {
+          color: $cool-grey;
+          opacity: 1;
+          font-size: 1em;
+        }
+        &::-moz-placeholder {
+          color: $cool-grey;
+          opacity: 1;
+          font-size: 1em;
+        }
+        &:-ms-input-placeholder {
+          color: $cool-grey;
+          font-size: 1em;
+          opacity: 1;
+        }
+      }
+
+      button[type="submit"] {
+        margin-left: 0;
+        position: absolute;
+        top: 5px;
+        left: 5px;
+        height: 30px;
+        width: 30px;
+        padding: 0;
+        line-height: 0;
+        -webkit-appearance: none;
+        display: block;
+        background: transparent;
+        background-image: url("../img/icons/search_16.svg");
+        background-repeat: no-repeat;
+        background-position: center;
+        background-size: 16px;
+        text-indent: -9999px;
+      }
+    }
+
+    .versions-nav {
+      padding: 1em 0;
+
+      .unavailable {
+        text-decoration: line-through;
+        color: $warm-grey;
+      }
+
+      .label {
+        display: block;
+        margin-bottom: .5em;
+      }
+
+      ul {
+        display: inline;
+        border-right: 1px solid $light-mid-grey;
+        padding-bottom: .2em;
+
+        li {
+          display: inline-block;
+          margin-right: .3em;
+
+          a {
             padding: 0;
+            margin: 0;
+            border-bottom: 1px solid $warm-grey;
+            text-decoration: none;
+            line-height: 1.1;
+          }
 
-            input[type="text"] {
-                @include box-shadow(none);
-                position: relative;
-                background-color: #fff;
-                height: 40px;
-                border: 1px solid $light-mid-grey;
-                padding-left: 35px;
-                color: $cool-grey;
-
-                &:focus {
-                    border: 1px solid #9D9C9A;
-                    outline: none;
-                }
-
-                &::-webkit-input-placeholder {
-                	color: $cool-grey;
-                	font-size: 1em;
-                  opacity: 1;
-                }
-                &:-moz-placeholder {
-                	color: $cool-grey;
-                	opacity: 1;
-                	font-size: 1em;
-                }
-                &::-moz-placeholder {
-                	color: $cool-grey;
-                	opacity: 1;
-                	font-size: 1em;
-                }
-                &:-ms-input-placeholder {
-                	color: $cool-grey;
-                	font-size: 1em;
-                  opacity: 1;
-                }
-            }
-
-            button[type="submit"] {
-                margin-left: 0;
-                position: absolute;
-                top: 5px;
-                left: 5px;
-                height: 30px;
-                width: 30px;
-                padding: 0;
-                line-height: 0;
-                -webkit-appearance: none;
-                display: block;
-                background: transparent;
-                background-image: url("../img/icons/search_16.svg");
-                background-repeat: no-repeat;
-                background-position: center;
-                background-size: 16px;
-                text-indent: -9999px;
-            }
+          strong {
+            border-bottom: 1px solid $ubuntu_orange;
+          }
         }
+      }
 
-        .versions-nav {
-            padding: 1em 0;
+      .stable {
+        margin-left: .5em;
+        border-bottom: 1px solid $warm-grey;
+        text-decoration: none;
+      }
+    }
+  }
 
-            .unavailable {
-                text-decoration: line-through;
-                color: $warm-grey;
-            }
+  .note {
+    padding: 20px;
+    background-color: #fdf6e7;
+    border: 1px solid #eca918;
+    border-radius: 2px;
+    color: inherit;
+  }
 
-            .label {
-                display: block;
-                margin-bottom: .5em;
-            }
+  &__content {
+    padding: 10px;
 
-            ul {
-                display: inline;
-                border-right: 1px solid $light-mid-grey;
-                padding-bottom: .2em;
-
-                li {
-                    display: inline-block;
-                    margin-right: .3em;
-
-                    a {
-                        padding: 0;
-                        margin: 0;
-                        border-bottom: 1px solid $warm-grey;
-                        text-decoration: none;
-                        line-height: 1.1;
-                    }
-
-                    strong {
-                      border-bottom: 1px solid $ubuntu_orange;
-                    }
-                }
-            }
-
-            .stable {
-                margin-left: .5em;
-                border-bottom: 1px solid $warm-grey;
-                text-decoration: none;
-            }
-        }
+    @media only screen and (min-width: $breakpoint-medium) {
+      padding: 20px 40px;
     }
 
-    .note {
-        padding: 20px;
-        background-color: #fdf6e7;
-        border: 1px solid #eca918;
-        border-radius: 2px;
-        color: inherit;
+    iframe {
+      margin: 0.25em 0 1em 0;
+      width: 100%;
     }
 
-    &__content {
-        padding: 10px;
-
-        @media only screen and (min-width: $breakpoint-medium) {
-            padding: 20px 40px;
-        }
-
-        iframe {
-            margin: 0.25em 0 1em 0;
-            width: 100%;
-        }
-
-        dl+h2 {
-          margin-top: .563em;
-        }
-
-        dl+p {
-          margin-top: .75em;
-        }
-
-        dt {
-          margin: 1em 0 0.5em;
-        }
-
-        pre {
-            background-color: $cool-grey;
-            border: none;
-            color: $mid-grey;
-
-            code {
-                margin-bottom: 0;
-                color: $mid-grey;
-            }
-        }
+    dl+h2 {
+      margin-top: .563em;
     }
+
+    dl+p {
+      margin-top: .75em;
+    }
+
+    dt {
+      margin: 1em 0 0.5em;
+    }
+
+    pre {
+      background-color: $cool-grey;
+      border: none;
+      color: $mid-grey;
+
+      code {
+        margin-bottom: 0;
+        color: $mid-grey;
+      }
+    }
+  }
 }
 
 // Make main section fill the vertical space (sticky footer)

--- a/_sass/_documentation.scss
+++ b/_sass/_documentation.scss
@@ -263,6 +263,7 @@
 .docs .wrapper {
   flex: 1;
   display: flex;
+  margin: 0;
 }
 
 .documentation {

--- a/_sass/_footer.scss
+++ b/_sass/_footer.scss
@@ -44,3 +44,12 @@
     padding: 2rem 0 1rem;
   }
 }
+
+.footer-wrapper {
+    -webkit-box-shadow: inset 0 2px 2px -1px #cdcdcd;
+    box-shadow: inset 0 2px 2px -1px #cdcdcd;
+    padding-top: 30px;
+    padding-bottom: 20px;
+    padding-left: 1rem;
+    padding-right: 1rem;
+}

--- a/_sass/_footer.scss
+++ b/_sass/_footer.scss
@@ -46,10 +46,10 @@
 }
 
 .footer-wrapper {
-    -webkit-box-shadow: inset 0 2px 2px -1px #cdcdcd;
-    box-shadow: inset 0 2px 2px -1px #cdcdcd;
-    padding-top: 30px;
-    padding-bottom: 20px;
-    padding-left: 1rem;
-    padding-right: 1rem;
+  -webkit-box-shadow: inset 0 2px 2px -1px #cdcdcd;
+  box-shadow: inset 0 2px 2px -1px #cdcdcd;
+  padding-top: 30px;
+  padding-bottom: 20px;
+  padding-left: 1rem;
+  padding-right: 1rem;
 }

--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -1,4 +1,3 @@
-.banner .nav-primary ul li:last-child,
 .banner .nav-primary ul li a,
 .banner .nav-primary ul li a:link,
 .banner .nav-primary ul li a:visited {
@@ -26,16 +25,10 @@
   }
 
   .logo {
-
     padding-top: .25rem;
-
-    @media only screen and (max-width: 1060px) {
-      padding-left: 1rem;
-    }
   }
 
   .nav-primary {
-
     @media only screen and (min-width: calc($site-max-width + 2rem)) {
       padding: 0;
     }
@@ -49,22 +42,15 @@
       float: right;
 
       li {
-
         @media only screen and (min-width: 620px) {
-
-          border-bottom: 3px solid #fff;
+          border-bottom: 3px solid transparent;
 
           &.active {
             border-bottom: 3px solid #e95420;
           }
 
           &:hover {
-            background-color: #e3e3e3!important;
-            border-bottom: 3px solid #e3e3e3;
-          }
-
-          a {
-            background: none!important;
+            background-color: #e3e3e3 !important;
           }
         }
       }
@@ -73,31 +59,21 @@
         border-right: 1px solid #e3e3e3;
         border-left: 1px solid #e3e3e3;
 
-        a {
-          padding-right: 1rem;
-          margin-right: .5rem;
-          display: inline-block;
-        }
-
         .docs & {
           border-right: 0;
           padding-right: 0;
         }
       }
 
-      li a.external:link:hover {
-        background-image:url('https://assets.ubuntu.com/v1/7d47725b-external-link.svg');
-        background-position: 95% 1rem;
-        background-size: .7em .7em;
+      li .external, li a.external:link, li a.external:link:hover {
+        color: $cool-grey;
+        background-image: url('https://assets.ubuntu.com/v1/7d47725b-external-link.svg');
+        background-position: right 1rem top 1rem;
+        background-size: 7px 7px;
         background-repeat: no-repeat;
+        background-color: transparent;
+        padding-right: 2rem;
       }
     }
   }
-
-  ul li .external {
-    color: $cool-grey;
-    background-image:url('https://assets.ubuntu.com/v1/7d47725b-external-link.svg')!important;
-    background-position: 95% 1rem;
-    padding-right: 3rem;
-  }
-}
+ }

--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -1,21 +1,3 @@
-.banner .nav-primary ul li a,
-.banner .nav-primary ul li a:link,
-.banner .nav-primary ul li a:visited {
-  border: 0;
-}
-
-.banner .logo {
-  margin: 0;
-
-  img {
-    height: 33px;
-  }
-}
-
-.banner .nav-primary ul {
-  float: right;
-}
-
 .banner {
   background: $white;
   max-width: $site-max-width;
@@ -25,17 +7,47 @@
   }
 
   .logo {
-    padding-top: .25rem;
+    height: 48px;
+    margin-top: 0;
+    margin-bottom: 0;
+    margin-left: 20px;
+    margin-right: 20px;
+
+    .docs & {
+      margin-left: 20px;
+    }
+
+    @media only screen and (min-width: 1060px) {
+      margin-left: 0;
+    }
+    @media only screen and (min-width: 768px) {
+      height: 51px;
+    }
+
+    img {
+      height: 28px;
+      display: block;
+    }
   }
 
   .nav-primary {
+    ul {
+      float: right;
+    }
+
+    ul li a,
+    ul li a:link,
+    ul li a:visited {
+      border: 0;
+    }
+
     @media only screen and (min-width: calc($site-max-width + 2rem)) {
       padding: 0;
     }
 
     .docs & {
       max-width: 100%;
-      padding: 0 1rem;
+      padding: 0;
     }
 
     ul {

--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -53,6 +53,18 @@
             background-color: #e3e3e3 !important;
           }
         }
+        a, a:link, a:link:hover {
+          background-color: transparent;
+        }
+        a.external, a.external:link, a.external:link:hover {
+          color: $cool-grey;
+          background-image: url('https://assets.ubuntu.com/v1/7d47725b-external-link.svg');
+          background-position: right 1rem top 1rem;
+          background-size: 7px 7px;
+          background-repeat: no-repeat;
+          background-color: transparent;
+          padding-right: 2rem;
+        }
       }
 
       li:last-child {
@@ -63,16 +75,6 @@
           border-right: 0;
           padding-right: 0;
         }
-      }
-
-      li .external, li a.external:link, li a.external:link:hover {
-        color: $cool-grey;
-        background-image: url('https://assets.ubuntu.com/v1/7d47725b-external-link.svg');
-        background-position: right 1rem top 1rem;
-        background-size: 7px 7px;
-        background-repeat: no-repeat;
-        background-color: transparent;
-        padding-right: 2rem;
       }
     }
   }

--- a/_sass/docs.scss
+++ b/_sass/docs.scss
@@ -16,4 +16,4 @@ $ubuntu_orange:    #dd4814;
 @import "base";
 @import "header";
 @import "documentation";
-@import "docs-footer";
+@import "footer";

--- a/index.html
+++ b/index.html
@@ -206,7 +206,7 @@ apps:
                     <img src="{{ site.asset_path }}74bd0daf-interfaces-+plugs-and-slots.svg" />
                 </p>
 
-                <p class="complementing-note">These two snaps can be connected becuase they have a plug
+                <p class="complementing-note">These two snaps can be connected because they have a plug
                 and a slot with a matching interface.</p>
 
                 <p>The interfaces are declared in the <code class="command-inline">snap.yaml</code> metadata:</p>


### PR DESCRIPTION
- Footer:
  - Fix #127: Footer is now simpler and doesn't add a rogue horizontal line on small screens
  - Fix #130: Footer in `/docs` sticks to bottom of screen on short pages (a working version of #142)
  - Tidy: Consolidate footer code in one include
- Header:
  - Fix #141: FAQ now has external link icon, and hopefully the right amount of space
  - Fix hover state on main nav items to "active" orange bar doesn't disappear
  - Tidy: Consolidate header code in one include
- Docs left navigation:
  - Fix #126: Now the font size in the docs navigation should remain the same on all screen sized
  - New docs navigation styling, to follow patterns from MAAS and Jujudocs
- Behind the scenes:
  - Unify indentation in SCSS (use `?w=1` to see diff without indentation changes)
  - Remove redundant table-of-contents markup from docs section

QA
---

Run the site and:

- Across the site, check man nav:
  - Has the correct amount of spacing and external link icon shows correctly.
  - Hover states have correct colours and orange bar doesn't disappear
- In `/docs`, check footer is at the bottom
- Across `/docs` section:
  - Check on small screens that footer doesn't have extra lines above it
  - Check left navigation font size remains consistent on all screen sizes
  - Check navigation looks and functions in a totally awesome new way
