### PR TITLE
Automatically add IDs to links

### DIFF
--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -8,6 +8,15 @@
   })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
   /**
+   * Add IDs to all links
+   */
+  anchors = document.querySelectorAll('a[href]');
+  for (var aNum = 0; aNum < anchors.length; aNum++) {
+    anchor = anchors[aNum];
+    anchor.id = anchor.innerText.split(' ').join('-');
+  }
+
+  /**
    * Register our Google Analytics ID
    */
   ga('create', 'UA-1018242-33', 'auto');


### PR DESCRIPTION
Google Analytics' Enhanced Link Attribution (https://support.google.com/analytics/answer/2558867?hl=en) needs each link to have an ID to distinguish them, so this JavaScript will automatically give links IDs corresponding to the link text.

This implementation does leave the possibility of two links with the same ID. We should obviously try to avoid this by giving links unique link text. But I think if we do get ID conflicts, the worst that wil probably happen is that link attribution won't work perfectly for those links, which is not the end of the world.

http://programmers.stackexchange.com/questions/127178/two-html-elements-with-same-id-attribute-how-bad-is-it-really

QA
--

Load a page, inspect a link, look at its ID.