### PR TITLE
Add Yocto/OpenEmbedded logos to list of supported distributions

### DIFF
--- a/_includes/contextual-footer.html
+++ b/_includes/contextual-footer.html
@@ -2,7 +2,7 @@
     <div class="wrapper equal-height--vertical-divider">
         <div class="six-col equal-height--vertical-divider__item">
             <h3>Learn more</h3>
-            <p>Want to know more about Snaps, snapd, Snapcraft &amp; Ubuntu Core?</p>
+            <p>Want to know more about snaps, snapd, Snapcraft and Ubuntu Core?</p>
             <ul class="no-bullets">
                 <li><a href="/docs">Read the docs</a></li>
                 <li><a href="http://askubuntu.com/search?q=snappy" class="external">Ask Ubuntu</a></li>
@@ -11,11 +11,11 @@
         </div>
         <div class="six-col last-col equal-height--vertical-divider__item">
             <h3>Contribute</h3>
-            <p>Interested in building Snaps or working with Ubuntu Core?</p>
+            <p>Interested in building snaps or working with Ubuntu Core?</p>
             <ul class="no-bullets">
-                <li><a href="/create">Create a Snap</a></li>
+                <li><a href="/create">Create a snap</a></li>
                 <li><a href="/community">Community</a></li>
-                <li><a href="https://github.com/snapcore/snapd" class="external">Fork me on Github!</a></li>
+                <li><a href="https://github.com/snapcore/snapd" class="external">Fork me on GitHub!</a></li>
             </ul>
         </div>
     </div>

--- a/_includes/footer-legal.html
+++ b/_includes/footer-legal.html
@@ -5,4 +5,6 @@
     <li class="footer__list-item"><a href="https://github.com/ubuntudesign/snapcraft.io/issues/new">Report a bug on this site</a></li>
 </ul>
 
+<p class="note six-col">Yocto Project and all related marks and logos are trademarks of The Linux Foundation. This website is not, in any way, endorsed by the Yocto Project or The Linux Foundation.</p>
+
 <span class="accessibility-aid"><a href="#">Go to the top of the page</a></span>

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -82,7 +82,6 @@
 .complementing-note {
   margin: 1rem auto 1rem;
   text-align: center;
-  font-weight: bold;
   font-style: italic;
   width: 100%;
 

--- a/_sass/_inline-logos.scss
+++ b/_sass/_inline-logos.scss
@@ -1,12 +1,13 @@
 .inline-logos {
-  padding-top: 0;
+  padding-top: 40px;
 
   .inline-logos__item {
     margin: 0;
+    height: auto;
 
     @media only screen and (min-width: $breakpoint-medium) {
       margin-right: 20px;
-      margin-bottom: 60px;
+      margin-bottom: 40px;
     }
   }
 }

--- a/_sass/_inline-logos.scss
+++ b/_sass/_inline-logos.scss
@@ -3,9 +3,10 @@
 
   .inline-logos__item {
     margin: 0;
+
     @media only screen and (min-width: $breakpoint-medium) {
       margin-right: 20px;
-      margin-bottom: 30px;
+      margin-bottom: 60px;
     }
   }
 }
@@ -13,7 +14,7 @@
 @media only screen and (min-width: $breakpoint-medium) {
   .inline-logos .inline-logos__image {
     max-height: 90px;
-    max-width: 240px;
+    max-width: 160px;
   }
 }
 

--- a/community/index.html
+++ b/community/index.html
@@ -10,7 +10,7 @@ layout: default
             application, you’ll find plenty of help here. Joining the growing
             community of Snappy developers is as simple as signing up to a <a class="external" href="https://lists.snapcraft.io/mailman/listinfo/snapcraft">mailing
             list</a> or have some fun in the <a class="external" href="https://github.com/ubuntu/snappy-playpen">Snappy Playpen.</a></p>
-            <p>Interacting with the Snappy community can be useful in other ways,
+            <p>Interacting with the Snappy community can be useful in other ways
             too. It can help you attract new users for your app, and it can be a
             great way to start contributing to the platform’s most popular projects.</p>
         </div>
@@ -43,14 +43,14 @@ layout: default
                     <h3><a href="https://github.com/ubuntu/snappy-playpen">Enter the Snappy Playpen ›</a></h3>
                     <p>Join the Snappy Playpen, where a community of developers
                     regularly work together to snap the most popular Linux apps. See
-                    apps, example code and documentation on <a class="external" href="https://github.com/ubuntu/snappy-playpen/">Github</a> – and join the
+                    apps, example code and documentation on <a class="external" href="https://github.com/ubuntu/snappy-playpen/">GitHub</a> – and join the
                     discussion on <a class="external" href="https://gitter.im/ubuntu/snappy-playpen">Gitter.</a></p>
                 </div>
 
                 <div class="six-col last-col box">
                     <h3><a href="https://lists.snapcraft.io/mailman/listinfo/snapcraft">Join the mailing list ›</a></h3>
-                    <p>Join the <a class="external" href="https://lists.ubuntu.com/mailman/listinfo/snapcraft">snapcraft mailing list</a> to ask any questions. You’ll also
-                    get regular product and community updates, from new snapcraft releases
+                    <p>Join the <a class="external" href="https://lists.ubuntu.com/mailman/listinfo/snapcraft">Snapcraft mailing list</a> to ask any questions. You’ll also
+                    get regular product and community updates, from new Snapcraft releases
                     to new snaps built by the community.</p>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -3,17 +3,14 @@ layout: default
 ---
 
     <section class="row hero-row no-border">
-        <div class="wrapper equal-height">
-            <div class="five-col equal-height__item equal-height__align-vertically">
-                <div>
-                    <h1 class="accessibility-aid">Snapcraft</h1>
-                    <p class="intro">Package any app for every Linux desktop,
-                    server, cloud or device, and deliver updates directly</p>
-                    <p><a href="/create">Learn to craft snaps</a>
-                    or <a href="/community">Join the community</a></p>
-                </div>
-            </div>
-            <div class="six-col equal-height__item equal-height__align-vertically prepend-one last-col">
+        <div class="wrapper">
+            <div class="eight-col prepend-two">
+                <h1 class="accessibility-aid">Snapcraft</h1>
+                <p class="intro">Package any app for every Linux desktop,
+                server, cloud or device, and deliver updates directly.</p>
+                <p><a href="/create">Learn to craft snaps</a>
+                or <a href="/community">join the community</a></p>
+
                 <ul class="inline-logos">
                     <li class="inline-logos__item">
                         <img class="inline-logos__image" src="{{ site.asset_path }}c086ad34-logo-ubuntu_st_no-black_orange-hex.svg" alt="ubuntu" />
@@ -41,13 +38,13 @@ layout: default
                     </li>
                 </ul>
                 <div class="align-center clearfix">
-                    <p>Click for <a href="/docs/core/install">installation instructions</a>, or <a href="http://www.github.com/snapcore/snapd">build <code>snapd</code> from source</a>.</p>
+                    <p>Read the <a href="/docs/core/install">installation instructions</a> or <a href="http://www.github.com/snapcore/snapd">build <code>snapd</code> from source</a></p>
                 </div>
             </div>
         </div>
     </section>
 
-    <section class="row hero-row no-border" style="background:#f7f7f7">
+    <section class="row hero-row no-border row-grey">
         <div class="wrapper">
             <div class="twelve-col">
                 <div class="equal-height--vertical-divider">
@@ -63,7 +60,7 @@ layout: default
                       servers, desktops to mobile devices.</p>
                   </div>
                   <div class="equal-height--vertical-divider__item four-col last-col">
-                      <h3>Github and beyond</h3>
+                      <h3>GitHub and beyond</h3>
                       <p>The public collection of snaps includes the best of GitHub and beyond,
                       so you have the whole world of Linux at your fingertips.</p>
                   </div>
@@ -168,7 +165,17 @@ $ tree
             </div>
 
             <div class="four-col last-col">
-                <img src="{{ site.asset_path }}bcba60c8-hadware-vertical-stack-update.svg" alt="Hardware manufacturer logos" />
+                <ul class="inline-logos">
+                    <li class="inline-logos__item">
+                        <img class="inline-logos__image" src="{{ site.asset_path }}c24cb4b9-logo-intel.svg" alt="intel" />
+                    </li>
+                    <li class="inline-logos__item">
+                        <img class="inline-logos__image" src="{{ site.asset_path }}b5352dc1-logo-arm.svg" alt="arm" />
+                    </li>
+                    <li class="inline-logos__item">
+                        <img class="inline-logos__image" src="{{ site.asset_path }}47e40767-power8.png" alt="power8" />
+                    </li>
+                </ul>
             </div>
 
             <div class="eight-col">

--- a/index.html
+++ b/index.html
@@ -6,20 +6,44 @@ layout: default
         <div class="wrapper equal-height">
             <div class="five-col equal-height__item equal-height__align-vertically">
                 <div>
-                    <h1 class="intro"><span class="accessibility-aid">Snapcraft -</span>Package any app for every Linux desktop,
-                    server, cloud or device, and deliver updates directly</h1>
+                    <h1 class="accessibility-aid">Snapcraft</h1>
+                    <p class="intro">Package any app for every Linux desktop,
+                    server, cloud or device, and deliver updates directly</p>
                     <p><a href="/create">Learn to craft snaps</a>
                     or <a href="/community">Join the community</a></p>
                 </div>
             </div>
-            <div class="six-col equal-height__item equal-height__align-vertically prepend-one last-col ">
-                <div>
-                    <img style="margin:1rem 0" src="{{ site.asset_path }}d0c2921d-hero-artwork%403x.png?w=500" />
-                    <div class="align-center clearfix">
-                        <p>Click for <a href="/docs/core/install">installation instructions</a>, or <a href="http://www.github.com/snapcore/snapd">build <code>snapd</code> from source</a>.</p>
-                    </div>
+            <div class="six-col equal-height__item equal-height__align-vertically prepend-one last-col">
+                <ul class="inline-logos">
+                    <li class="inline-logos__item">
+                        <img class="inline-logos__image" src="{{ site.asset_path }}c086ad34-logo-ubuntu_st_no-black_orange-hex.svg" alt="ubuntu" />
+                    </li>
+                    <li class="inline-logos__item">
+                        <img class="inline-logos__image" src="{{ site.asset_path }}e0b23092-archlinux.svg" alt="archlinux" />
+                    </li>
+                    <li class="inline-logos__item last-col">
+                        <img class="inline-logos__image" src="{{ site.asset_path }}2eafb62e-openlogo.svg" alt="debian" />
+                    </li>
+                    <li class="inline-logos__item">
+                        <img class="inline-logos__image" src="{{ site.asset_path }}b6fa25ef-Gentoo-trans02.png" alt="gentoo" />
+                    </li>
+                    <li class="inline-logos__item">
+                        <img class="inline-logos__image" src="{{ site.asset_path }}1a53bedd-fedora.svg" alt="fedora" />
+                    </li>
+                    <li class="inline-logos__item last-col">
+                        <img class="inline-logos__image" src="{{ site.asset_path }}06469a26-official-logo-color.svg" alt="suse" />
+                    </li>
+                    <li class="inline-logos__item">
+                        <img class="inline-logos__image" src="{{ site.asset_path }}d243274d-openembedded-logo.svg" alt="openembedded" />
+                    </li>
+                    <li class="inline-logos__item">
+                        <img class="inline-logos__image" src="{{ site.asset_path }}d9a1a359-yocto-project-transp.png" alt="yocto project" />
+                    </li>
+                </ul>
+                <div class="align-center clearfix">
+                    <p>Click for <a href="/docs/core/install">installation instructions</a>, or <a href="http://www.github.com/snapcore/snapd">build <code>snapd</code> from source</a>.</p>
                 </div>
-           </div>
+            </div>
         </div>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -522,7 +522,7 @@ Hello (beta) 1.2 installed</code></pre>
                 <h2>Get crafting!</h2>
                 <p>Snaps have a very simple internal structure - you can easily
                 craft them by hand!</p>
-                <p>But the easiest way to build a snap is with <em>snapcraft</em>, which
+                <p>But the easiest way to build a snap is with Snapcraft, which
                 supports building from source and from existing packages. Snapcraft
                 also handles publishing your snaps to the world.</p>
                 <p>Read how to create a snap and join the snap-crafting community


### PR DESCRIPTION
## Done
- Fix up the header syntax
- Converted the supported logos into a inline-logo list
- Added Yocto/OpenEmbedded logos

## QA

- Check the homepage looks ok
- Check the logos are all the same although maybe slightly different sizes

## Issue / Card

Fixes https://github.com/ubuntudesign/snapcraft.io/issues/160, https://github.com/ubuntudesign/snapcraft.io/issues/161, https://github.com/ubuntudesign/snapcraft.io/issues/155, https://github.com/ubuntudesign/snapcraft.io/issues/153, https://github.com/ubuntudesign/snapcraft.io/issues/152,

