### PR TITLE
Remove snap find --broad from the homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -305,9 +305,7 @@ hello        2.10     canonical  -      GNU Hello, the "hello world" snap
 hello-huge   1.0      noise      -      A really big snap
 hello-world  6.1      canonical  -      Hello world example</code></pre>
 
-                <p>You can expand the search to include snap descriptions with
-                <code class="command-inline">--broad</code> if you don’t find what you’re looking for just based on
-                the name.</p>
+                <p>In the future, you will be able to refine <code class="command-inline">snap find</code> queries with more parameters.</p>
 
                 <p>These examples use the Ubuntu store, your snap implementation
                 might be different, other stores are available and it is also easy


### PR DESCRIPTION
## Done

- Remove "snap find --broad" mention. This feature hasn't been implemented yet.

## Issue / Card

Fixes #163


