### PR TITLE
Word missing in create

### DIFF
--- a/create/index.html
+++ b/create/index.html
@@ -156,7 +156,7 @@ Cleaning up priming area
 $ ls
 hello_2.10_amd64.snap  snapcraft.yaml</code></pre>
 
-            <p>In some trees it may be preferable to name the snapcraft YAML file <code>.snapcraft.yaml</code>. Snapcraft will look for <code>snapcraft.yaml</code> or <code>.snapcraft.yaml</code>, and will use either one, but it will error out if you've both there. If you're uncertain, the recommendation is to use <code>snapcraft.yaml</code>.</p>
+            <p>In some trees it may be preferable to name the snapcraft YAML file <code>.snapcraft.yaml</code>. Snapcraft will look for <code>snapcraft.yaml</code> or <code>.snapcraft.yaml</code>, and will use either one, but it will error out if you've got both there. If you're uncertain, the recommendation is to use <code>snapcraft.yaml</code>.</p>
 
             <p>One last thing to be aware of is that the <code>snapcraft</code> command is shorthand for the real command, which is <code>snapcraft snap</code>. You can see this from the help for snapcraft:</p>
 


### PR DESCRIPTION
There was a word missing in the sentence: 

> Snapcraft will look for snapcraft.yaml or .snapcraft.yaml, and will use either one, but it will error out if you've both there.