### PR TITLE
Remove reference to multiple READMEs in the tour

### DIFF
--- a/create/index.html
+++ b/create/index.html
@@ -43,7 +43,7 @@ layout: default
 Snapcraft tour initialized in ./snapcraft-tour/
 Instructions are in the README, or http://snapcraft.io/create/#tour</code></pre>
 
-            <p>Each stage of the tour is in a separate subdirectory, with number prefixes showing the sequence. In each directory you'll find a README with the instructions from this page relevant to that directory, so you don't need to continually switch between the browser and your terminal as you follow the tour. </p>
+            <p>Each stage of the tour is in a separate subdirectory, with number prefixes showing the sequence.</p>
 
             <p>Unless you specify a different directory name, the tour will be created in a new <code>snapcraft-tour</code> subdirectory in your current working directory. The directory structure will look like:</p>
 


### PR DESCRIPTION
## Done

On the create page, removed reference to other READMEs in the tour

## QA

Text is correct.

## Issue / Card

Fixes #159 #169

## Notes

This is a temporary measure as these READMEs could appear in the future.