### PR TITLE
add id anchor links to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@ layout: default
     <section class="row hero-row no-border">
         <div class="wrapper equal-height">
             <div class="five-col equal-height__item equal-height__align-vertically">
-                <h1 class="accessibility-aid">Snapcraft</h1>
+                <h1 id="snapcraft_home_banner" class="accessibility-aid">Snapcraft</h1>
                 <p class="intro">Package any app for every Linux desktop,
                 server, cloud or device, and deliver updates directly.</p>
                 <p><a href="/create">Learn to craft snaps</a>
@@ -49,7 +49,7 @@ layout: default
         </div>
     </section>
 
-    <section class="row hero-row no-border row-grey">
+    <section id="snapcraft_home_install" class="row hero-row no-border row-grey">
         <div class="wrapper">
             <div class="twelve-col">
                 <div class="equal-height--vertical-divider">
@@ -74,7 +74,7 @@ layout: default
         </div>
     </section>
 
-    <section class="row">
+    <section id="snapcraft_home_how-snaps-work" class="row">
         <div class="wrapper">
             <div class="eight-col">
                 <h2>How do snaps work?</h2>
@@ -183,7 +183,7 @@ $ tree
                 </ul>
             </div>
 
-            <div class="eight-col">
+            <div id="snapcraft_home_how-snaps-work_read-only" class="eight-col">
                 <h3>Snaps are read-only and have segregated data stores</h3>
                 <p>Snaps are read-only for security. We want to prevent a hostile
                 party from sneakily changing the software on your machine, so you
@@ -224,7 +224,7 @@ $ tree
                architecture article.</a></p>
             </div>
 
-            <div class="eight-col">
+            <div id="snapcraft_home_how-snaps-work_integration" class="eight-col">
                 <h3>Snap integration with interfaces, plugs and slots</h3>
                 <p> Snaps are safely confined in their separate sandboxes by
                 sophisticated kernel security mechanisms. That means that snaps
@@ -270,7 +270,7 @@ $ tree
                 But there may be other plugs and slots you can connect up by
                 choice, and  snaps will document those individually.</p>
             </div>
-            <div class="eight-col">
+            <div id="snapcraft_home_how-snaps-work_architecture" class="eight-col">
                 <h3>The architecture of a snappy system</h3>
                 <p>So a snappy system has a collection of snaps, each of which
                 is read-only, each of which has its own set of independent
@@ -291,7 +291,7 @@ $ tree
         </div>
     </section>
 
-    <section class="row">
+    <section id="snapcraft_home_using-snaps" class="row">
         <div class="wrapper">
             <div class="eight-col">
                 <h2>Using snaps - the snappy "hello world" tour</h2>
@@ -341,7 +341,7 @@ hello    2.10      26      canonical     -
 core     16.04-55  109     canonical     -
 snapweb  0.17      21      canonical     -</code></pre>
             </div>
-            <div class="eight-col">
+            <div id="snapcraft_home_using-snaps_fresh" class="eight-col">
                 <h3>Always fresh – update fast and reliably</h3>
                 <p>Snaps are updated automatically in the background every day.
                 You can manually get the latest version of all your snaps with
@@ -356,7 +356,7 @@ core updated
 hello 64.75 MB [=====================================>___]   12s</code></pre>
             </div>
 
-            <div class="eight-col">
+            <div id="snapcraft_home_using-snaps_revert" class="eight-col">
                 <h3>And revert if something goes wrong!</h3>
                 <p>With the technology built in to snappy it is simple to roll
                 back to a previous version of an application for any reason.</p>
@@ -371,7 +371,7 @@ hello 64.75 MB [=====================================>___]   12s</code></pre>
  hello-world      6.0                    25   canonical  -</code></pre>
             </div>
 
-            <div class="eight-col">
+            <div id="snapcraft_home_using-snaps_channels" class="eight-col">
                 <h3>Stable, candidate, beta and edge channels</h3>
                 <p>Developers can release stable, candidate, beta and edge versions
                 of a snap, at the same time, to engage with a community who are
@@ -406,7 +406,7 @@ Hello (beta) 1.2 installed</code></pre>
     </section>
 
 
-    <section class="row">
+    <section id="snapcraft_home_featured-snaps" class="row">
         <div class="wrapper">
             <div class="seven-col">
                 <h2>Featured snaps</h2>
@@ -519,7 +519,7 @@ Hello (beta) 1.2 installed</code></pre>
         </div>
     </section>
 
-    <section class="row">
+    <section id="snapcraft_home_get-crafting" class="row">
         <div class="wrapper">
             <div class="eight-col">
                 <h2>Get crafting!</h2>


### PR DESCRIPTION
## Done

* added anchor links to all major sections on the homepage

## QA

1. go to the homepage and try any of the following anchors (e.g. http://snapcraft.io/#snapcraft_home_how-snaps-work)

* h1 id="snapcraft_home_banner"
* section id="snapcraft_home_install"
* section id="snapcraft_home_how-snaps-work"
* div id="snapcraft_home_how-snaps-work_read-only"
* div id="snapcraft_home_how-snaps-work_integration"
* div id="snapcraft_home_how-snaps-work_architecture"
* section id="snapcraft_home_using-snaps"
* div id="snapcraft_home_using-snaps_fresh"
* div id="snapcraft_home_using-snaps_revert"
* div id="snapcraft_home_using-snaps_channels"
* section id="snapcraft_home_featured-snaps"
* section id="snapcraft_home_get-crafting"

## Issue / Card

Fixes #177 

