### PR TITLE
create: snap login -> sudo snap login

### DIFF
--- a/create/index.html
+++ b/create/index.html
@@ -712,7 +712,7 @@ x-plugins: Local plugins</code></pre>
             <p>Once you've confirmed your account, you're ready to start pushing your snaps to the Store. Make sure Snapcraft and snap know about you by logging in using the email address you provided at signup:</p>
 
             <pre class="command-line code-block"><code>$ snapcraft login
-$ snap login you@yourdomain.com</code></pre>
+$ sudo snap login you@yourdomain.com</code></pre>
 
             <h4 id="devspace">devspace: you can generally publish your own version of a snap</h4>
 


### PR DESCRIPTION
## Done

Users need to run sudo snap login instead of snap login:

* Content fix in create/

## QA

"sudo snap login" works, "snap login" doesn't.
