### PR TITLE
replace htop with rocket.chat

### DIFF
--- a/index.html
+++ b/index.html
@@ -423,10 +423,10 @@ Hello (beta) 1.2 installed</code></pre>
                 </li>
                 <li class="equal-height__align-vertically grid-list__item four-col">
                     <div class="one-col ">
-                        <img class="grid-list__img" src="{{ site.asset_path }}3ea99f54-htop.svg" alt="icon">
+                        <img class="grid-list__img" src="{{ site.asset_path }}b3155b2d-Rocket-dot-Chat.svg" alt="icon">
                     </div>
                     <div class="three-col last-col">
-                        <h3>htop</h3>
+                        <h3>Rocket.Chat</h3>
                     </div>
                 </li>
                 <li class="equal-height__align-vertically grid-list__item four-col last-col">


### PR DESCRIPTION
## Done

Replace htop in featured snaps with rocket.chat

## QA

1. go to the homepage
2. see that rocket.chat is there instead of htop

## Issue / Card

Fixes #189

## Screenshots

![image](https://cloud.githubusercontent.com/assets/441217/18378702/657c465e-7666-11e6-8864-5b07d2d30ee5.png)


