### PR TITLE
Change intro font-size on small screens

### DIFF
--- a/_sass/_hero.scss
+++ b/_sass/_hero.scss
@@ -10,19 +10,23 @@ $dark_aubergine: #2c001e;
   padding-top: 20px;
   padding-bottom: 0;
 
+  .intro {
+    font-size: .875rem;
+  }
+
   @media only screen and (min-width: $breakpoint-medium) {
     padding-top: 60px;
     padding-bottom: 20px;
+
+    .intro {
+      font-size: 23px;
+      line-height: 1.5;
+    }
   }
 
   @media only screen and (min-width: 984px) {
     &__heading {
       margin-top: 2rem;
     }
-  }
-
-  .intro {
-    font-size: 23px;
-    line-height: 1.5;
   }
 }


### PR DESCRIPTION
## Done

Make intro paragraph on /create normal font-size (14px) on small screens - now once it hits the medium breakpoint, it jumps to 23px as before.

## QA

- Sync code
- Scale /create through breakpoints from small and observe 'Snapcraft is a snappy packaging tool.' change font-size.

## Issue / Card

Fixes #156 

