### PR TITLE
Homepage refresh command fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -349,11 +349,11 @@ snapweb  0.17      21      canonical     -</code></pre>
                 snaps, unless you specify particular snaps to refresh.</p>
 
 
-<pre class="command-line code-block"><code>$ sudo snap refresh krita
-krita already up to date
+<pre class="command-line code-block"><code>$ sudo snap refresh hello
+hello already up to date
 $ sudo snap refresh
-core updated
-hello 64.75 MB [=====================================>___]   12s</code></pre>
+core 64.75 MB [=====================================>___]   12s
+core updated</code></pre>
             </div>
 
             <div id="snapcraft_home_using-snaps_revert" class="eight-col">


### PR DESCRIPTION
The refresh command example on the homepage is confusing. This commit fixes it by using snap names that make sense with the rest of the content.