### PR TITLE
Remove Snappy Playpen CTA as it’s now deprecated

### DIFF
--- a/community/index.html
+++ b/community/index.html
@@ -39,14 +39,6 @@ layout: default
                     to a single question.</p>
                 </div>
 
-                <div class="six-col box">
-                    <h3><a href="https://github.com/ubuntu/snappy-playpen">Enter the Snappy Playpen ›</a></h3>
-                    <p>Join the Snappy Playpen, where a community of developers
-                    regularly work together to snap the most popular Linux apps. See
-                    apps, example code and documentation on <a class="external" href="https://github.com/ubuntu/snappy-playpen/">GitHub</a> – and join the
-                    discussion on <a class="external" href="https://gitter.im/ubuntu/snappy-playpen">Gitter.</a></p>
-                </div>
-
                 <div class="six-col last-col box">
                     <h3><a href="https://lists.snapcraft.io/mailman/listinfo/snapcraft">Join the mailing list ›</a></h3>
                     <p>Join the <a class="external" href="https://lists.ubuntu.com/mailman/listinfo/snapcraft">Snapcraft mailing list</a> to ask any questions. You’ll also


### PR DESCRIPTION
## Done

Removed Playpen promo from /community page

## QA

- Run code
- Navigate to /community
- Check that 'Enter the Snappy Playpen ›' promo box has been removed

## Issue / Card

Fixes: #245
