### PR TITLE
Editing create page to reflect the deprecation warning when using 'up…

### DIFF
--- a/create/index.html
+++ b/create/index.html
@@ -792,7 +792,7 @@ $ sudo snap login you@yourdomain.com</code></pre>
 
             <p>Once you've registered your snap name, go back to your <code>snapcraft.yaml</code> file and update the name field. Run Snapcraft again to quickly rebuild with the new name. With that done, the new revision of your snap can be uploaded to the Store:</p>
 
-            <pre class="command-line code-block"><code>$ snapcraft upload hello-world_1.0_*.snap</code></pre>
+            <pre class="command-line code-block"><code>$ snapcraft push hello-world_1.0_*.snap</code></pre>
 
             <h4 id="publication">publication: users only see your published revisions</h4>
 

--- a/po-html/snapcraft.io.pot
+++ b/po-html/snapcraft.io.pot
@@ -1288,7 +1288,7 @@ msgid "Open your browser at"
 msgstr ""
 
 #: ../create/index.html
-msgid "$ snapcraft upload hello-world_1.0_*.snap"
+msgid "$ snapcraft push hello-world_1.0_*.snap"
 msgstr ""
 
 #: ../create/index.html


### PR DESCRIPTION
…load'

command.

"DEPRECATED: Use `push` instead of `upload`"
