### PR TITLE
Fix broken example links on the create page

### DIFF
--- a/create/index.html
+++ b/create/index.html
@@ -747,7 +747,7 @@ apps:</p>
 
             <h4 id="autoconf-make">autoconf-make: the standard "configure, make, make install" plugin</h4>
 
-            <p><a class="external" href="https://github.com/ubuntu-core/snapcraft/blob/master/demos/libpipeline/snapcraft.yaml">See an example on Github</a></p>
+            <p><a class="external" href="https://github.com/ubuntu-core/snapcraft/blob/master/demos/libpipeline/snap/snapcraft.yaml">See an example on Github</a></p>
 
             <p>Get more info from:</p>
 
@@ -756,7 +756,7 @@ $ snapcraft help make</code></pre>
 
             <h4 id="golang">golang: the Golang plugin</h4>
 
-            <p><a class="external" href="https://github.com/ubuntu-core/snapcraft/blob/master/demos/godd/snapcraft.yaml">See an example on Github</a></p>
+            <p><a class="external" href="https://github.com/ubuntu-core/snapcraft/blob/master/demos/godd/snap/snapcraft.yaml">See an example on Github</a></p>
 
             <p>Get more info from:</p>
 

--- a/po-html/snapcraft.io.pot
+++ b/po-html/snapcraft.io.pot
@@ -1203,7 +1203,7 @@ msgstr ""
 #: ../create/index.html
 msgid ""
 "https://github.com/ubuntu-"
-"core/snapcraft/blob/master/demos/godd/snapcraft.yaml"
+"core/snapcraft/blob/master/demos/godd/snap/snapcraft.yaml"
 msgstr ""
 
 #: ../create/index.html
@@ -1822,7 +1822,7 @@ msgstr ""
 #: ../create/index.html
 msgid ""
 "See https://github.com/ubuntu-"
-"core/snapcraft/blob/master/demos/libpipeline/snapcraft.yaml"
+"core/snapcraft/blob/master/demos/libpipeline/snap/snapcraft.yaml"
 msgstr ""
 
 #: ../create/index.html


### PR DESCRIPTION
## Done

Drive-by patch, I was on snapcraft.io and noticed some broken links

## QA

Search on the https://snapcraft.io/create/ page for "See an example on Github". The two links like that are currently broken. This should correct that.

## Issue / Card

[List of links to Github issues/bugs and cards if needed - e.g. `Fixes #1`]

## Screenshots

[if relevant, include a screenshot]
