### PR TITLE
Make caldav a champion

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,5 +49,7 @@ Then re-run the site with `gulp`.
 
 Code licensed [LGPLv3](http://opensource.org/licenses/lgpl-3.0.html) by [Canonical Ltd.](http://www.canonical.com/).
 
+[caldav](https://github.com/caldav) is the champion for this project.
+
 With ♥ from Canonical
 


### PR DESCRIPTION
@barrymcgee has up until now been the unspoken champion of snapcraft.io, but almost all issues really require @caldav's input.

This will officially make @caldav the champion of this project and therefore the first port of call for issues. You don't have to respond to all of them right away or anything, just try to keep an eye on them.

@caldav let me know if this isn't okay.